### PR TITLE
Update v2rdm_solver.h

### DIFF
--- a/v2rdm_solver.h
+++ b/v2rdm_solver.h
@@ -127,6 +127,11 @@ class v2RDMSolver: public Wavefunction{
     double nalpha_;
     double nbeta_;
 
+    /// Number of doubly occupied per irrep
+    Dimension doccpi_;
+    /// Number of singly occupied per irrep
+    Dimension soccpi_;
+    
     /// constrain Q2 to be positive semidefinite?
     bool constrain_q2_;
 


### PR DESCRIPTION
These changes _should_ get V2RDM working with #2619. If V2RDM wants docc and socc so badly, it'll have to clean up after them.