### PR TITLE
Psi compatibility fixes, should have been in previous commit

### DIFF
--- a/natural_orbitals.cc
+++ b/natural_orbitals.cc
@@ -564,7 +564,7 @@ void v2RDMSolver::PrintNaturalOrbitalOccupations() {
 
     SharedMatrix Da (new Matrix(nirrep_,nmopi_,nmopi_));
     SharedMatrix eigveca (new Matrix(nirrep_,nmopi_,nmopi_));
-    SharedVector eigvala (new Vector("Natural Orbital Occupation Numbers (alpha)", mopi_));
+    SharedVector eigvala (new Vector("Natural Orbital Occupation Numbers (alpha)", nmopi_));
 
     for (int h = 0; h < nirrep_; h++) {
         for (int i = 0; i < frzcpi_[h] + rstcpi_[h]; i++) {

--- a/v2rdm_solver.cc
+++ b/v2rdm_solver.cc
@@ -139,7 +139,6 @@ v2RDMSolver::~v2RDMSolver()
     free(d2_plus_core_sym_);
     free(d1_act_spatial_sym_);
 
-    free(amopi_);
     free(rstcpi_);
     free(rstvpi_);
     free(d2aboff);
@@ -257,8 +256,7 @@ void  v2RDMSolver::common_init(){
     memset((void*)rstvpi_,'\0',nirrep_*sizeof(int));
 
     // active orbitals per irrep:
-    amopi_    = (int*)malloc(nirrep_*sizeof(int));
-    memset((void*)amopi_,'\0',nirrep_*sizeof(int));
+    amopi_ = Dimension(nirrep_);
 
     // multiplicity:
     multiplicity_ = Process::environment.molecule()->multiplicity();

--- a/v2rdm_solver.h
+++ b/v2rdm_solver.h
@@ -39,6 +39,7 @@
 #include <psi4/libpsio/psio.hpp>
 #include <psi4/libqt/qt.h>
 
+#include <psi4/libmints/dimension.h>
 #include <psi4/libmints/wavefunction.h>
 #include <psi4/libmints/matrix.h>
 #include <psi4/libmints/vector.h>
@@ -194,7 +195,7 @@ class v2RDMSolver: public Wavefunction{
     int nrstv_;
 
     /// active molecular orbitals per irrep
-    int * amopi_;
+    Dimension amopi_;
 
     /// restricted core orbitals per irrep.  these will be optimized optimized
     int * rstcpi_;


### PR DESCRIPTION
Fixes obvious typo.
Changes amopi_ type to Dimension, as it should have been from the beginning.